### PR TITLE
15 craft error order

### DIFF
--- a/Classes/CraftOutput.lua
+++ b/Classes/CraftOutput.lua
@@ -87,7 +87,7 @@ function CraftLogger.CraftOutput:Generate(recipeData, craftingItemResultData)
 					print("CraftLogger: Error, Order Reagent Not Found.")
 					error()
 				end
-				if reagentItem.quantity ~= 0 then
+				if reagentItem.quantity ~= 0 and not (not reagent.hasQuality and reagentItem.quantity == orderReagent.reagent.quantity) then
 					print("CraftLogger: Error, Order Reagent Already Has Quantity.")
 					error()
 				end


### PR DESCRIPTION
fix #15 
Issue is that non-quality reagents are always set regardless of craftingreagentinfotbl or schematicform. Included a specific exception case for this, which theoretically covers everything so this section can eventually be removed later after enough testing.